### PR TITLE
Fix handling of FailureTarget transcoding status

### DIFF
--- a/src/oscClient.js
+++ b/src/oscClient.js
@@ -479,7 +479,7 @@ class OSCClient {
                 status = 'processing';
             } else if (jobDetails.status === 'Complete' || jobDetails.status === 'SuccessCriteriaMet') {
                 status = 'completed';
-            } else if (jobDetails.status === 'Failed' || jobDetails.status === 'Error') {
+            } else if (jobDetails.status === 'Failed' || jobDetails.status === 'Error' || jobDetails.status === 'FailureTarget') {
                 status = 'failed';
             } else if (jobDetails.status === 'Suspended') {
                 status = 'suspended';


### PR DESCRIPTION
## Summary
- Add FailureTarget to the list of statuses that map to 'failed' in transcoding job status handler
- Ensures transcoding jobs returning FailureTarget status are properly recognized as failed jobs
- Users will now see appropriate error messages for FailureTarget status

## Test plan
- [ ] Start a transcoding job that fails with FailureTarget status
- [ ] Verify the frontend displays the error message correctly
- [ ] Confirm the job is marked as failed in the system

🤖 Generated with [Claude Code](https://claude.ai/code)