### PR TITLE
fix: poll MinIO endpoint readiness and retry bucket creation on startup

### DIFF
--- a/src/oscClient.js
+++ b/src/oscClient.js
@@ -224,6 +224,13 @@ class OSCClient {
                 throw new Error('MinIO instance created but not ready yet');
             }
 
+            // The control plane returns the URL as soon as the instance record
+            // exists, which can be before the ingress route is actually serving.
+            // Poll the endpoint's health check until it answers so callers don't
+            // race the ingress (and hit its fake self-signed cert) when opening
+            // an S3 connection right afterwards.
+            await this.waitForMinioEndpointReady(instanceDetails.url);
+
             return {
                 instanceName,
                 endpoint: instanceDetails.url,
@@ -236,6 +243,34 @@ class OSCClient {
             console.error('Failed to create MinIO instance via OSC API:', error);
             throw error;
         }
+    }
+
+    // Poll the MinIO endpoint's own health check until it responds, so we don't
+    // return before the ingress route is actually live. Bounded retries — never
+    // loops forever. Mirrors the control-plane poll loop above in style.
+    async waitForMinioEndpointReady(endpoint, maxRetries = 30, delayMs = 2000) {
+        const healthUrl = `${endpoint.replace(/\/+$/, '')}/minio/health/live`;
+        let retries = 0;
+
+        while (retries < maxRetries) {
+            try {
+                const response = await fetch(healthUrl, { method: 'GET' });
+                if (response.ok) {
+                    console.log(`MinIO endpoint is live and serving: ${endpoint}`);
+                    return true;
+                }
+                console.log(`MinIO endpoint not serving yet (HTTP ${response.status}), waiting... (${retries + 1}/${maxRetries})`);
+            } catch (error) {
+                // Connection refused / TLS not ready / DNS not resolving yet while
+                // the ingress route comes up — keep polling until it settles.
+                console.log(`MinIO endpoint not reachable yet (${error.message}), waiting... (${retries + 1}/${maxRetries})`);
+            }
+
+            await new Promise(resolve => setTimeout(resolve, delayMs));
+            retries++;
+        }
+
+        throw new Error(`MinIO endpoint did not become ready at ${healthUrl} after ${maxRetries} attempts`);
     }
 
     async getMinioInstance(instanceName) {
@@ -300,20 +335,50 @@ class OSCClient {
 
         const results = [];
 
-        for (const bucketName of bucketNames) {
-            try {
-                // Check if bucket already exists
-                let bucketExists = false;
+        // Distinguish "bucket is missing" from "the endpoint/ingress is flapping".
+        // A missing bucket means we should create it; a transient network/TLS/5xx
+        // error during startup should be retried, not treated as "not found".
+        const isTransientError = (error) => {
+            if (!error) return false;
+            const retriableCodes = ['NetworkingError', 'TimeoutError', 'RequestTimeout',
+                'InternalError', 'ServiceUnavailable', 'SlowDown', 'ECONNREFUSED',
+                'ECONNRESET', 'EPIPE', 'ETIMEDOUT', 'ENOTFOUND', 'EAI_AGAIN'];
+            const statusCode = error.statusCode || (error.originalError && error.originalError.statusCode);
+            if (statusCode && statusCode >= 500) return true;
+            if (error.code && retriableCodes.includes(error.code)) return true;
+            // Ingress default cert before the real route is live.
+            if (typeof error.message === 'string' && /self-signed certificate|self signed certificate/i.test(error.message)) return true;
+            return false;
+        };
+
+        // Ensure a single bucket exists, retrying transient route flaps during
+        // startup so one early failure isn't terminal. Bounded — never infinite.
+        const ensureBucket = async (bucketName, maxRetries = 10, delayMs = 3000) => {
+            let attempt = 0;
+            for (;;) {
                 try {
                     await s3.headBucket({ Bucket: bucketName }).promise();
-                    bucketExists = true;
                     console.log(`Bucket '${bucketName}' already exists`);
+                    return true; // existed
                 } catch (headError) {
-                    // Bucket doesn't exist, we'll create it
+                    if (isTransientError(headError) && attempt < maxRetries) {
+                        attempt++;
+                        console.warn(`headBucket('${bucketName}') hit a transient error (${headError.code || headError.message}), retrying... (${attempt}/${maxRetries})`);
+                        await new Promise(resolve => setTimeout(resolve, delayMs));
+                        continue;
+                    }
+                    // Not transient (or out of retries) — treat as "bucket missing" and create it.
                     console.log(`Creating bucket: ${bucketName}`);
                     await s3.createBucket({ Bucket: bucketName }).promise();
                     console.log(`Successfully created bucket: ${bucketName}`);
+                    return false; // created
                 }
+            }
+        };
+
+        for (const bucketName of bucketNames) {
+            try {
+                const bucketExists = await ensureBucket(bucketName);
                 
                 // If this is the output bucket and makeOutputPublic is true, set public read policy
                 if (bucketName === 'output' && makeOutputPublic) {

--- a/src/server.js
+++ b/src/server.js
@@ -82,6 +82,17 @@ async function setupMinioForScheduler(instanceName = 'schedulerstorage', usernam
       true // Make output bucket public
     );
 
+    // Don't let a failed bucket be swallowed: createMinioBuckets records
+    // per-bucket failures in its results instead of throwing, so a startup that
+    // could not create its storage would otherwise look healthy. Surface it.
+    const failedBuckets = (bucketResults || []).filter((r) => !r.success);
+    if (failedBuckets.length > 0) {
+      const detail = failedBuckets
+        .map((r) => `${r.bucket}: ${r.error}`)
+        .join('; ');
+      throw new Error(`MinIO bucket setup failed for: ${detail}`);
+    }
+
     console.log('MinIO setup completed:', {
       instance: minioConfig.instanceName,
       endpoint: minioConfig.endpoint,
@@ -1306,6 +1317,9 @@ fastify.get('/api/channels/:id/status', async (request, reply) => {
 
 // Global flag to track setup state
 let isSettingUpStorage = false;
+// Records the last storage-setup failure so it isn't silently swallowed — a
+// startup that couldn't create its buckets must not look healthy.
+let storageSetupError = null;
 
 // Setup page HTML
 const setupPageHtml = `<!DOCTYPE html>
@@ -1383,6 +1397,19 @@ fastify.get('/api/osc-status', async (request, reply) => {
   }
 });
 
+// Report storage-setup health so a failed startup is visible instead of silent.
+fastify.get('/api/storage/status', async (request, reply) => {
+  const ready = !isSettingUpStorage && !storageSetupError;
+  if (!ready && storageSetupError) {
+    reply.code(503);
+  }
+  return {
+    settingUp: isSettingUpStorage,
+    ready,
+    error: storageSetupError
+  };
+});
+
 // Global preHandler for setup mode
 fastify.addHook('preHandler', async (request, reply) => {
   if (isSettingUpStorage && !request.url.startsWith('/api/')) {
@@ -1404,9 +1431,13 @@ const start = async () => {
       isSettingUpStorage = true;
       try {
         await setupMinioForScheduler();
+        storageSetupError = null;
         console.log('MinIO storage setup completed');
       } catch (error) {
-        console.warn('MinIO setup failed during startup:', error.message);
+        // Surface loudly at error level and keep the failure visible via the
+        // /api/storage/status endpoint rather than swallowing it as a warning.
+        storageSetupError = error.message;
+        console.error('MinIO setup FAILED during startup — storage is not ready:', error);
       }
       isSettingUpStorage = false;
     }


### PR DESCRIPTION
## Summary
- Implements #12: MinIO bucket creation fails on first startup because the OSC control plane returns the instance URL before the ingress route is actually serving; the first HTTPS/S3 handshake hits the ingress controller's default self-signed certificate and the AWS SDK aborts with `Error: self-signed certificate`. With no retry, a single early failure left the instance running with zero buckets, and the failure was swallowed so the app looked healthy.

## Changes
- `src/oscClient.js` — `createMinioInstance` now calls a new `waitForMinioEndpointReady(url)` after the control-plane poll, polling `{url}/minio/health/live` until HTTP 200 (bounded 30×2s), treating TLS/connection errors as "not ready yet".
- `src/oscClient.js` — `createMinioBuckets` gains bounded retry (`ensureBucket`, 10×3s) around `headBucket`/`createBucket`, retrying transient errors (5xx, network codes, `self-signed certificate`) while still creating genuinely-missing buckets. Return shape unchanged.
- `src/server.js` — `setupMinioForScheduler` now throws if any bucket failed (zero-bucket startup no longer looks healthy); the failure is logged at error level and recorded as `storageSetupError`, surfaced via a new `GET /api/storage/status` (503 on failure).

## Test plan
channel-scheduler has no configured test script (`npm test` fails by design), so verification is manual:
- PROOF: `node --check src/oscClient.js && node --check src/server.js` → both OK
- PROOF: stubbed-`fetch` exercise of `waitForMinioEndpointReady` → ready-after-2-retries (calls=3); bounded throw after exactly 4 attempts; URL normalized to `https://x.example/minio/health/live`
- PROOF: stubbed-`aws-sdk` exercise of `createMinioBuckets` → 2 transient `self-signed certificate` errors retried, then `NotFound` → bucket created (headCalls=3)
- PROOF: `node index.js` (scratch sqlite DB, no OSC token, PORT=3999) → server listened, seeded DB, cleanly skipped MinIO setup, new route registered, no throw

Honest note: the live ingress-race path only triggers against a real OSC MinIO deploy (control plane returns a URL before the ingress route serves) and cannot be exercised locally; the stubbed tests above verify the polling/retry/surfacing logic is syntactically and logically sound.

Closes #12

🤖 Automated via Channel Engine Dev daily-backlog-pr skill