### PR TITLE
fix: derive isOnAir from stream reachability instead of OSC instance status

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1237,48 +1237,54 @@ fastify.get('/api/channels/:id/status', async (request, reply) => {
       statusDetails.isWebhookOnline = isWebhookOnline;
     }
     
-    // Check Channel Engine status via OSC API first
+    // Enrich the reported status string via the OSC API. This is treated as
+    // enrichment only: the OSC instance object does not carry a health field,
+    // so it must not be the sole source of truth for isOnAir (see #13).
+    let oscStatusString = null;
     if (oscClient.isConfigured()) {
       try {
         const oscStatus = await oscClient.getChannelEngineStatus(channel.channelEngineInstance);
         if (!oscStatus.error) {
-          isOnAir = oscStatus.isRunning || false;
-          status = oscStatus.status || 'unknown';
+          if (oscStatus.status) {
+            oscStatusString = oscStatus.status;
+          }
           statusDetails = { oscStatus: oscStatus.details };
         }
       } catch (oscError) {
         console.error('Failed to get OSC status:', oscError);
       }
     }
-    
-    // Fallback: Check if Channel Engine stream is accessible
-    if (channel.channelEngineUrl && (!oscClient.isConfigured() || status === 'unknown')) {
+
+    // Primary signal: is the Channel Engine stream reachable? A reachable
+    // manifest means the channel is on air, regardless of whether OSC is
+    // configured — the OSC call above only enriches the status string.
+    if (channel.channelEngineUrl) {
       try {
         const response = await fetch(channel.channelEngineUrl, { method: 'HEAD' });
         const streamAccessible = response.ok;
-        
-        if (!oscClient.isConfigured()) {
-          isOnAir = streamAccessible;
-          status = streamAccessible ? 'on_air' : 'offline';
-        }
-        
+
+        isOnAir = streamAccessible;
+        status = streamAccessible ? 'on_air' : 'offline';
         statusDetails.streamAccessible = streamAccessible;
       } catch (error) {
         statusDetails.streamError = error.message;
-        if (!oscClient.isConfigured()) {
-          status = 'error';
-        }
+        isOnAir = false;
+        status = 'error';
       }
     }
-    
-    // Use webhook status as fallback or if no other method worked
-    if (isWebhookOnline && (status === 'offline' || status === 'unknown')) {
+
+    // Additional positive signal: a recent webhook call confirms the channel is
+    // live even if the stream check above did not mark it on air. Never used to
+    // force isOnAir false — only to rescue it to true.
+    if (isWebhookOnline && !isOnAir) {
       status = 'online_webhook';
       isOnAir = true;
-    } else if (status === 'offline' && isWebhookOnline) {
-      // Prefer webhook status for "online" indication
-      status = 'online_webhook';
-      isOnAir = true;
+    }
+
+    // If OSC provided a meaningful status string, surface it (unless a positive
+    // webhook rescue already set a more specific one).
+    if (oscStatusString && status !== 'online_webhook') {
+      statusDetails.oscStatusString = oscStatusString;
     }
     
     // Update status in database


### PR DESCRIPTION
## Summary
- Implements #13: `GET /api/channels/:id/status` reported `isOnAir: false` for a channel that was demonstrably live. Status-reporting bug only — playback/scheduling were unaffected. On Open Source Cloud all three signals that could set `isOnAir` failed: the OSC instance object has no `.status` field (so `isRunning` was permanently false), the correct stream-reachability signal was computed then discarded because it was gated behind `!oscClient.isConfigured()` (always false on OSC, where `OscAccessToken` is required), and the webhook rescue expired between clip boundaries (2-min window vs. multi-minute clips).

## Changes
- `src/server.js` (`GET /api/channels/:id/status`) — OSC call is now enrichment only: it contributes a `status` string when present but no longer drives `isOnAir`.
- `src/server.js` — stream-reachability fetch now always drives `isOnAir = streamAccessible` (`status` = `on_air`/`offline`) whenever the channel engine URL exists, regardless of `oscClient.isConfigured()`; removed the dead gating that discarded the correct signal on OSC.
- `src/server.js` — webhook recency is now an additional positive rescue only, never required for `isOnAir` to be true. Response shape/fields preserved.

## Test plan
channel-scheduler has no configured test script (`npm test` fails by design); verification is manual:
- PROOF: `node --check src/server.js` → `server.js OK`; `node --check src/oscClient.js` → `oscClient.js OK`
- PROOF: isolated decision-logic replica with stubbed reachability fetch:
  - OSC configured, OSC status undefined, stale webhook, manifest reachable → `isOnAir=true status=on_air` (the #13 case)
  - manifest unreachable + stale webhook → `isOnAir=false status=offline`
  - manifest unreachable + fresh webhook → `isOnAir=true status=online_webhook`
  - fetch throws → `isOnAir=false status=error`

Honest note: repo has no test infra and none was invented; the isolated test mirrors the exact branch structure but is not the live handler. The full live path (real Prisma channel, real HLS HEAD request, real OSC context) can only be exercised on an actual OSC deploy.

Closes #13

🤖 Automated via Channel Engine Dev daily-backlog-pr skill