### PR TITLE
fix: check prisma db push exit code before starting app on first boot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,12 @@ if [ ! -f "${DATA_DIR}/prod.db" ]; then\n\
   HEALTH_PID=$!\n\
   \n\
   echo "Initializing database..."\n\
-  npx prisma db push\n\
+  if ! npx prisma db push; then\n\
+    echo "Database initialization failed"\n\
+    kill $HEALTH_PID 2>/dev/null || true\n\
+    wait $HEALTH_PID 2>/dev/null || true\n\
+    exit 1\n\
+  fi\n\
   \n\
   # Stop health server\n\
   echo "Database initialization complete, stopping health server..."\n\


### PR DESCRIPTION
## Summary
- Implements #20: the Docker first-boot init script (`start.sh`, generated in the `Dockerfile` heredoc) ran `npx prisma db push` with no exit-code check and then unconditionally `exec npm start`, silently starting the app against a broken/incomplete schema when a migration failed.

## Changes
- `Dockerfile`: wrapped `npx prisma db push` in an `if ! ...; then` guard that, on failure, prints `Database initialization failed`, stops the placeholder health server (`kill`/`wait $HEALTH_PID`, matching the existing success-path cleanup), and `exit 1` — so a failed first-boot migration stops the container before `npm start`. The success path is byte-for-byte unchanged.

## Test plan
No test script is configured in this repo (by design), so verified manually by reconstructing `start.sh` exactly as the Dockerfile heredoc produces it and stubbing `node`/`npx`/`npm` on PATH:
- `bash -n start.sh` → syntax OK.
- Failing `prisma db push` (stub exit 1): prints `Database initialization failed`, health-server stub killed, `npm start` never reached, script exits `1`.
- Succeeding `prisma db push` (stub exit 0, `prod.db` absent): reaches `npm start`, exits `0`.

Finding on `src/healthServer.js`: referenced ONLY from this `start.sh` (`node /app/src/healthServer.js`); a repo-wide grep found no other imports (`src/server.js`, `index.js`, `docker-compose.yml` etc.). It is a first-boot placeholder page, not truly dead, so it is left in place — removing it is out of scope for this minimal fix.

Closes #20

🤖 Automated via Channel Engine Dev daily-backlog-pr skill