### PR TITLE
fix: handle empty-channel webhook gracefully instead of 500 per poll

### DIFF
--- a/src/webhook.js
+++ b/src/webhook.js
@@ -1,6 +1,27 @@
 const { PrismaClient } = require('@prisma/client');
 const prisma = new PrismaClient();
 
+// A defined "no content" result the Channel Engine can accept without erroring.
+// Returned for channels that have no scheduled clips so an empty channel does not
+// produce a 500 on every ~5s webhook poll.
+const EMPTY_VOD = Object.freeze({ id: null, title: null, hlsUrl: null, empty: true });
+
+// Throttle the "empty channel" log so it is emitted at most once per channel rather
+// than on every poll. Keyed by channelId; value is the last time we logged for it.
+const emptyChannelLoggedAt = new Map();
+const EMPTY_CHANNEL_LOG_INTERVAL_MS = 60 * 60 * 1000; // at most once per hour per channel
+
+function logEmptyChannelOnce(channelId) {
+  const last = emptyChannelLoggedAt.get(channelId);
+  const now = Date.now();
+  if (last === undefined || now - last >= EMPTY_CHANNEL_LOG_INTERVAL_MS) {
+    console.log(
+      `Channel ${channelId} has no scheduled clips - returning empty/no-content result (suppressing repeat logs)`
+    );
+    emptyChannelLoggedAt.set(channelId, now);
+  }
+}
+
 async function getNextVod(channelId) {
   try {
     const now = new Date();
@@ -30,11 +51,9 @@ async function getNextVod(channelId) {
       });
     }
 
-    // If still no item, we're looping back to the beginning
+    // If still no item, we're either looping back to the beginning or the channel
+    // is empty. Get the first item by position to tell the two cases apart.
     if (!schedule) {
-      console.log(`No upcoming schedule items found for channel ${channelId}, looping back to beginning and updating schedule times`);
-      
-      // Get the first item by position
       schedule = await prisma.schedule.findFirst({
         where: {
           channelId,
@@ -45,6 +64,9 @@ async function getNextVod(channelId) {
       });
 
       if (schedule) {
+        // A real loop-back: there are clips, we just ran past the last window.
+        console.log(`No upcoming schedule items found for channel ${channelId}, looping back to beginning and updating schedule times`);
+
         // Update the entire schedule to start from now
         const { rebalanceSchedule } = require('./schedulingUtils');
         
@@ -72,7 +94,12 @@ async function getNextVod(channelId) {
     }
 
     if (!schedule) {
-      throw new Error('No schedule found for channel');
+      // Every lookup (current window, next upcoming, loop-back by position) came up
+      // empty, so this channel genuinely has no active scheduled clips. Rather than
+      // throwing (which the route turns into a 500 on every poll), return a defined
+      // no-content result and log at most once per channel.
+      logEmptyChannelOnce(channelId);
+      return { ...EMPTY_VOD };
     }
 
     const response = {


### PR DESCRIPTION
## Summary
- Implements #15: an empty channel (no scheduled clips) no longer returns a 500 on every ~5s webhook poll.

## Changes
- `src/webhook.js`: replace the terminal `throw` on the empty-schedule path with a defined no-content response `{ id: null, title: null, hlsUrl: null, empty: true }` (returned as 200 the engine can accept); add a per-channel throttled logger (at most once/hour/channel) and gate the loop-back log so neither spams every poll.

## Scope
- Empty-channel path only. Clip-rotation is #14 (separate PR); these branches intentionally do not stack.

## Test plan
- No test script configured in this repo (by design). PROOF: `node --check src/webhook.js` OK; in-process harness against a real Prisma/sqlite DB, empty channel, 4 consecutive polls each returned `{"id":null,"title":null,"hlsUrl":null,"empty":true}` with no throw and exactly one log line across all 4 polls.
- Not verified over HTTP: `node index.js` in simulation mode (no OSC_ACCESS_TOKEN) serves a pre-existing storage-setup gate on all routes; verified behaviorally via the exported `getNextVod`.

Closes #15

🤖 Automated via Channel Engine Dev daily-backlog-pr skill