### PR TITLE
fix: fail HLS duration detection instead of substituting a 5-minute placeholder

### DIFF
--- a/src/hlsUtils.js
+++ b/src/hlsUtils.js
@@ -1,55 +1,73 @@
 const axios = require('axios');
 const HLS = require('hls-parser');
 
+// Duration detection result sources. Callers MUST use these to decide whether
+// a duration is trustworthy enough to persist/schedule.
+//   MEASURED  - summed from real segment durations; safe to store
+//   ESTIMATED - guessed from targetDuration; usable but flagged as inexact
+// Hard failures (unreachable/404/timeout/unparseable/no-variants/no-data) throw
+// instead of returning a placeholder, so a dead manifest can never masquerade
+// as a valid-looking asset.
+const DURATION_SOURCE = {
+  MEASURED: 'measured',
+  ESTIMATED: 'estimated'
+};
+
+/**
+ * Detect the duration of an HLS asset.
+ *
+ * @param {string} hlsUrl
+ * @returns {Promise<{durationMs: number, source: string}>}
+ *   source is one of DURATION_SOURCE.MEASURED | DURATION_SOURCE.ESTIMATED.
+ * @throws {Error} on any hard detection failure (network, 404, timeout,
+ *   unparseable manifest, master playlist with no variants, media playlist
+ *   with no segments and no targetDuration). Callers must treat a thrown
+ *   error as "duration unknown" and NOT persist a placeholder.
+ */
 async function getHLSDuration(hlsUrl) {
-  try {
-    console.log(`Fetching HLS manifest from: ${hlsUrl}`);
-    
-    const response = await axios.get(hlsUrl, {
-      timeout: 10000,
-      headers: {
-        'User-Agent': 'Channel-Scheduler/1.0'
-      }
-    });
+  console.log(`Fetching HLS manifest from: ${hlsUrl}`);
 
-    const manifest = HLS.parse(response.data);
-    
-    if (manifest.isMasterPlaylist) {
-      // If it's a master playlist, get the first variant and fetch its media playlist
-      if (manifest.variants && manifest.variants.length > 0) {
-        const variantUrl = new URL(manifest.variants[0].uri, hlsUrl).href;
-        return await getHLSDuration(variantUrl);
-      }
-      throw new Error('Master playlist has no variants');
+  const response = await axios.get(hlsUrl, {
+    timeout: 10000,
+    headers: {
+      'User-Agent': 'Channel-Scheduler/1.0'
     }
+  });
 
-    // Calculate total duration from media playlist
-    let totalDuration = 0;
-    
-    if (manifest.segments && manifest.segments.length > 0) {
-      // Sum up all segment durations
-      for (const segment of manifest.segments) {
-        totalDuration += segment.duration || 0;
-      }
-    } else if (manifest.targetDuration) {
-      // Fallback: estimate based on target duration and segment count
-      const estimatedSegments = 10; // Default estimation
-      totalDuration = manifest.targetDuration * estimatedSegments;
-      console.warn(`No segments found, estimating duration: ${totalDuration}s`);
+  const manifest = HLS.parse(response.data);
+
+  if (manifest.isMasterPlaylist) {
+    // If it's a master playlist, get the first variant and fetch its media playlist
+    if (manifest.variants && manifest.variants.length > 0) {
+      const variantUrl = new URL(manifest.variants[0].uri, hlsUrl).href;
+      return await getHLSDuration(variantUrl);
     }
-
-    const durationMs = Math.round(totalDuration * 1000);
-    console.log(`Detected HLS duration: ${totalDuration}s (${durationMs}ms)`);
-    
-    return durationMs;
-  } catch (error) {
-    console.error('Error detecting HLS duration:', error.message);
-    
-    // Return a default duration if detection fails
-    const defaultDurationMs = 300000; // 5 minutes
-    console.warn(`Using default duration: ${defaultDurationMs}ms`);
-    return defaultDurationMs;
+    throw new Error('Master playlist has no variants');
   }
+
+  // Media playlist: prefer a real measurement from the segment list.
+  if (manifest.segments && manifest.segments.length > 0) {
+    let totalDuration = 0;
+    for (const segment of manifest.segments) {
+      totalDuration += segment.duration || 0;
+    }
+    const durationMs = Math.round(totalDuration * 1000);
+    console.log(`Measured HLS duration: ${totalDuration}s (${durationMs}ms)`);
+    return { durationMs, source: DURATION_SOURCE.MEASURED };
+  }
+
+  // No segments: we can only estimate from targetDuration. Flag it as an
+  // ESTIMATE so callers can distinguish it from a real measurement.
+  if (manifest.targetDuration) {
+    const estimatedSegments = 10; // Default estimation
+    const totalDuration = manifest.targetDuration * estimatedSegments;
+    const durationMs = Math.round(totalDuration * 1000);
+    console.warn(`No segments found, estimating duration: ${totalDuration}s (${durationMs}ms)`);
+    return { durationMs, source: DURATION_SOURCE.ESTIMATED };
+  }
+
+  // Nothing usable in the manifest - this is a hard failure, not a placeholder.
+  throw new Error('Media playlist has no segments and no targetDuration');
 }
 
 async function validateHLSUrl(hlsUrl) {
@@ -73,5 +91,6 @@ async function validateHLSUrl(hlsUrl) {
 
 module.exports = {
   getHLSDuration,
-  validateHLSUrl
+  validateHLSUrl,
+  DURATION_SOURCE
 };

--- a/src/seedData.js
+++ b/src/seedData.js
@@ -49,9 +49,10 @@ async function seedDatabase() {
             
             try {
                 // Auto-detect duration from HLS manifest
-                const durationMs = await getHLSDuration(vodData.hlsUrl);
-                console.log(`Detected duration: ${Math.round(durationMs / 1000)}s`);
-                
+                const detection = await getHLSDuration(vodData.hlsUrl);
+                const durationMs = detection.durationMs;
+                console.log(`Detected duration: ${Math.round(durationMs / 1000)}s (${detection.source})`);
+
                 await prisma.vOD.create({
                     data: {
                         title: vodData.title,
@@ -60,20 +61,13 @@ async function seedDatabase() {
                         durationMs: durationMs
                     }
                 });
-                
+
                 console.log(`✓ Added: ${vodData.title}`);
             } catch (error) {
+                // Detection failed: skip seeding this asset entirely rather than
+                // persisting a placeholder duration for a dead manifest.
                 console.error(`Failed to process ${vodData.title}:`, error.message);
-                // Create without duration if detection fails
-                await prisma.vOD.create({
-                    data: {
-                        title: vodData.title,
-                        description: vodData.description,
-                        hlsUrl: vodData.hlsUrl,
-                        durationMs: 30000 // Default 30 seconds
-                    }
-                });
-                console.log(`✓ Added: ${vodData.title} (with default duration)`);
+                console.warn(`✗ Skipped: ${vodData.title} (duration could not be determined)`);
             }
         }
         

--- a/src/server.js
+++ b/src/server.js
@@ -15,7 +15,7 @@ const fastify = require('fastify')({
 const { PrismaClient } = require('@prisma/client');
 const path = require('path');
 const { registerWebhookRoutes } = require('./webhook');
-const { getHLSDuration, validateHLSUrl } = require('./hlsUtils');
+const { getHLSDuration, validateHLSUrl, DURATION_SOURCE } = require('./hlsUtils');
 const { calculateBackToBackSchedule, rebalanceSchedule, updateChannelScheduleStart } = require('./schedulingUtils');
 const { seedDatabase } = require('./seedData');
 const { OSCClient } = require('./oscClient');
@@ -317,14 +317,28 @@ fastify.get('/api/vods', async (request, reply) => {
 fastify.post('/api/vods', async (request, reply) => {
   try {
     const { title, description, hlsUrl, durationMs, prerollUrl, prerollDurationMs, metadata } = request.body;
-    
+
     // Auto-detect duration if not provided
     let finalDurationMs = durationMs;
     if (!finalDurationMs && hlsUrl) {
       console.log(`Auto-detecting duration for VOD: ${title}`);
-      finalDurationMs = await getHLSDuration(hlsUrl);
+      try {
+        const detection = await getHLSDuration(hlsUrl);
+        finalDurationMs = detection.durationMs;
+        if (detection.source === DURATION_SOURCE.ESTIMATED) {
+          console.warn(`Duration for "${title}" is an estimate, not a measurement: ${finalDurationMs}ms`);
+        }
+      } catch (detectError) {
+        // Duration is unknown: do NOT persist an asset with a placeholder
+        // duration - surface it as broken so it is not scheduled.
+        console.error(`Duration detection failed for "${title}" (${hlsUrl}):`, detectError.message);
+        return reply.code(422).send({
+          error: 'Could not determine VOD duration from HLS manifest',
+          details: detectError.message
+        });
+      }
     }
-    
+
     const vod = await prisma.vOD.create({
       data: {
         title,
@@ -981,8 +995,25 @@ fastify.post('/api/vods/detect-duration', async (request, reply) => {
       return reply.code(400).send({ error: 'hlsUrl is required' });
     }
     
-    const durationMs = await getHLSDuration(hlsUrl);
-    return { durationMs, durationSeconds: Math.round(durationMs / 1000) };
+    let detection;
+    try {
+      detection = await getHLSDuration(hlsUrl);
+    } catch (detectError) {
+      // Hard failure: the manifest is unreachable/unparseable. Report it as
+      // an unknown duration rather than a fabricated value.
+      console.error(`Duration detection failed for ${hlsUrl}:`, detectError.message);
+      return reply.code(422).send({
+        error: 'Could not determine duration from HLS manifest',
+        details: detectError.message
+      });
+    }
+
+    return {
+      durationMs: detection.durationMs,
+      durationSeconds: Math.round(detection.durationMs / 1000),
+      source: detection.source,
+      estimated: detection.source === DURATION_SOURCE.ESTIMATED
+    };
   } catch (error) {
     reply.code(500).send({ error: 'Failed to detect duration' });
   }


### PR DESCRIPTION
## Summary
- Implements #25: `getHLSDuration()` no longer returns a hardcoded 300000 ms on detection failure, so a dead/unreachable manifest can no longer be persisted as a valid-looking 5-minute asset.

## Changes
- `src/hlsUtils.js`: hard failures (network/404/timeout, unparseable manifest, master playlist with no variants, media playlist with no segments and no targetDuration) now **throw** instead of returning a placeholder. Success returns `{ durationMs, source }`; segment-summed durations are `MEASURED`, the no-segments `targetDuration * 10` case is flagged `ESTIMATED`. Exported new `DURATION_SOURCE` enum.
- `src/server.js`: `POST /api/vods` wraps detection in try/catch — on failure returns **HTTP 422** and does not persist the VOD; logs a warning when the duration is only an estimate. `POST /api/vods/detect-duration` returns 422 on hard failure and adds `source`/`estimated` to the success response.
- `src/seedData.js`: uses the new result shape; the old catch that persisted a 30000 ms placeholder is removed — a failed detection now **skips** seeding that asset.

## Test plan
channel-scheduler has no test runner configured (`npm test` is a stub by design), so verification is syntax checks + a throwaway stubbed-axios harness (not committed):
- PROOF: `node --check src/hlsUtils.js && node --check src/server.js && node --check src/seedData.js` → all OK
- PROOF: `node -e "require('./src/hlsUtils.js')"` → exports `[getHLSDuration, validateHLSUrl, DURATION_SOURCE]`
- PROOF: throwaway stub test → 404/failure throws (never returns 300000); segments → `MEASURED`; no-segments → `ESTIMATED` (never 300000)

Closes #25

🤖 Automated via Channel Engine Dev daily-backlog-pr skill