### PR TITLE
feat: surface FFmpeg exit code and stderr from getTranscodingJobStatus

### DIFF
--- a/src/oscClient.js
+++ b/src/oscClient.js
@@ -552,10 +552,45 @@ class OSCClient {
                 status = 'pending';
             }
 
+            // Surface the underlying ffmpeg process exit code and stderr so a failed
+            // transcode is diagnosable. The exact field names ffmpeg-s3 exposes on the
+            // OSC instance object are not confirmed from this repo, so read defensively
+            // across plausible shapes (best-effort until confirmed against a live job,
+            // tracked in issue #28). A running/pending job has no exit code yet, so
+            // these are simply undefined/null in that case (do not throw).
+            const firstPresent = (obj, keys) => {
+                if (!obj || typeof obj !== 'object') return undefined;
+                for (const key of keys) {
+                    if (obj[key] !== undefined && obj[key] !== null) {
+                        return obj[key];
+                    }
+                }
+                return undefined;
+            };
+
+            const exitCode = firstPresent(jobDetails, [
+                'exitCode', 'exit_code', 'code', 'returnCode', 'return_code'
+            ]);
+            const stderr = firstPresent(jobDetails, [
+                'stderr', 'errorOutput', 'error_output', 'logs', 'error', 'message'
+            ]);
+
+            if (status === 'failed') {
+                console.error(
+                    `Transcoding job '${jobName}' failed (oscStatus=${jobDetails.status}) ` +
+                    `exitCode=${exitCode === undefined ? 'n/a' : exitCode}`
+                );
+                if (stderr !== undefined) {
+                    console.error(`Transcoding job '${jobName}' stderr: ${stderr}`);
+                }
+            }
+
             return {
                 jobId: jobName,
                 status: status,
                 oscStatus: jobDetails.status,
+                exitCode: exitCode,
+                stderr: stderr,
                 details: jobDetails
             };
         } catch (error) {

--- a/src/server.js
+++ b/src/server.js
@@ -802,7 +802,9 @@ fastify.get('/api/transcode-status/:jobId', async (request, reply) => {
     return {
       jobId: jobStatus.jobId,
       status: jobStatus.status,
-      oscStatus: jobStatus.oscStatus
+      oscStatus: jobStatus.oscStatus,
+      exitCode: jobStatus.exitCode,
+      stderr: jobStatus.stderr
     };
 
   } catch (error) {


### PR DESCRIPTION
## Summary
- Implements #27: `getTranscodingJobStatus()` now surfaces the transcode process exit code and stderr so a failed job is diagnosable, instead of discarding them.

## Changes
- `src/oscClient.js`: added a defensive `firstPresent()` helper that reads the exit code and stderr from the OSC `jobDetails` object across several plausible field-name shapes (field names are best-effort until confirmed against a live job — tracked in #28). Added `exitCode`/`stderr` to the returned object (undefined when not applicable) and logs them server-side when the job is in a `failed` state. Existing return fields (`jobId`, `status`, `oscStatus`, `details`) are unchanged, and the OSC-status → status mapping is deliberately **not** touched (that is #24's scope).
- `src/server.js`: `GET /api/transcode-status/:jobId` now passes `exitCode` and `stderr` through in its JSON response.

## Test plan
channel-scheduler has no test runner (`npm test` is a stub by design); verified via syntax checks + a throwaway extraction harness (not committed):
- PROOF: `node --check src/oscClient.js && node --check src/server.js` → OK
- PROOF: `node -e "require('./src/oscClient.js')"` → loads OK
- PROOF: throwaway harness → extraction picks up exit code/stderr under camelCase (`exitCode`/`stderr`), snake/alt (`exit_code`/`errorOutput`), and `code`/`message` shapes; a running job and a null jobDetails both yield `undefined` with no throw

## Notes
Deliberately scoped to *surfacing* diagnostics only. The status-mapping fix (treating OSC `Complete` as "terminated, outcome unknown") is #24; the exit-234 root-cause investigation that consumes this output is #28.

Closes #27

🤖 Automated via Channel Engine Dev daily-backlog-pr skill