### PR TITLE
fix: verify FFmpeg exit code and HLS output before reporting transcode completed

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1518,7 +1518,12 @@ class ChannelScheduler {
         }
 
         try {
-            const response = await fetch(`/api/transcode-status/${this.currentTranscodingJob.jobId}`);
+            // Pass the expected HLS URL so the server can confirm the transcode
+            // actually wrote a fetchable master manifest before reporting it
+            // completed (issue #24).
+            const statusUrl = `/api/transcode-status/${this.currentTranscodingJob.jobId}`
+                + `?hlsUrl=${encodeURIComponent(this.currentTranscodingJob.hlsUrl || '')}`;
+            const response = await fetch(statusUrl);
             
             if (!response.ok) {
                 throw new Error('Failed to check transcoding status');
@@ -1551,9 +1556,13 @@ class ChannelScheduler {
                 this.currentTranscodingJob = null;
                 
             } else if (result.status === 'failed') {
+                const reason = result.failureReason
+                    || (result.exitCode !== undefined && result.exitCode !== null
+                        ? `ffmpeg exit code ${result.exitCode}`
+                        : null);
                 uploadSuccess.innerHTML = `
                     <i class="fas fa-times-circle mr-1 text-red-500"></i>
-                    <span class="text-red-600">Transcoding failed</span>
+                    <span class="text-red-600">Transcoding failed${reason ? `: ${reason}` : ''}</span>
                 `;
                 
                 // Re-enable save button on failure (user can still save with original file)

--- a/src/oscClient.js
+++ b/src/oscClient.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 const { Context, createInstance, listInstances, removeInstance, getInstance } = require('@osaas/client-core');
 const { createMinioMinioInstance, getMinioMinioInstance, removeMinioMinioInstance } = require('@osaas/client-services');
+const { validateHLSUrl } = require('./hlsUtils');
 
 // Try to import FFmpeg S3 functions (may not exist in current version)
 let createTranscodeEyevinnFfmpegS3Instance, getTranscodeEyevinnFfmpegS3Instance, removeTranscodeEyevinnFfmpegS3Instance;
@@ -518,14 +519,35 @@ class OSCClient {
         }
     }
 
-    async getTranscodingJobStatus(jobName) {
+    // Verify a terminated transcode actually produced a playable HLS master
+    // manifest at the expected output URL. The output bucket is created with a
+    // public-read policy (see createMinioBuckets), so a plain HTTP HEAD/GET via
+    // validateHLSUrl can confirm the manifest resolves. Returns true only when
+    // the manifest is fetchable and looks like an HLS playlist; false on any
+    // failure. Never throws — a check failure means "not verified", i.e. failed.
+    async isMasterManifestFetchable(masterManifestUrl) {
+        if (!masterManifestUrl) return false;
+        try {
+            return await validateHLSUrl(masterManifestUrl);
+        } catch (error) {
+            console.error(`Failed to fetch master manifest ${masterManifestUrl}: ${error.message}`);
+            return false;
+        }
+    }
+
+    // options.masterManifestUrl - expected HLS master manifest URL for this job's
+    //   output. When provided, a terminated ("Complete") job is only reported as
+    //   completed if that manifest is actually fetchable.
+    async getTranscodingJobStatus(jobName, options = {}) {
         if (!this.isConfigured()) {
             throw new Error('OSC_ACCESS_TOKEN environment variable is not configured');
         }
 
+        const { masterManifestUrl } = options;
+
         try {
             let jobDetails;
-            
+
             if (getTranscodeEyevinnFfmpegS3Instance) {
                 jobDetails = await getTranscodeEyevinnFfmpegS3Instance(this.context, jobName);
             } else {
@@ -536,20 +558,6 @@ class OSCClient {
 
             if (!jobDetails) {
                 throw new Error(`Transcoding job '${jobName}' not found`);
-            }
-
-            // Map OSC status to our status
-            let status = 'unknown';
-            if (jobDetails.status === 'Running') {
-                status = 'processing';
-            } else if (jobDetails.status === 'Complete' || jobDetails.status === 'SuccessCriteriaMet') {
-                status = 'completed';
-            } else if (jobDetails.status === 'Failed' || jobDetails.status === 'Error' || jobDetails.status === 'FailureTarget') {
-                status = 'failed';
-            } else if (jobDetails.status === 'Suspended') {
-                status = 'suspended';
-            } else {
-                status = 'pending';
             }
 
             // Surface the underlying ffmpeg process exit code and stderr so a failed
@@ -575,10 +583,51 @@ class OSCClient {
                 'stderr', 'errorOutput', 'error_output', 'logs', 'error', 'message'
             ]);
 
+            // Map OSC status to our status.
+            let status = 'unknown';
+            let failureReason;
+            if (jobDetails.status === 'Running') {
+                status = 'processing';
+            } else if (jobDetails.status === 'Complete' || jobDetails.status === 'SuccessCriteriaMet') {
+                // OSC "Complete" only means the container terminated, NOT that
+                // ffmpeg succeeded. A non-zero exit still terminates, so we must
+                // confirm the outcome before calling it completed (issue #24).
+                // Prefer the ffmpeg exit code when the instance exposes it; a
+                // non-zero exit is an unambiguous failure. Independently, verify
+                // the expected HLS master manifest actually landed and is
+                // fetchable, so a clean exit that wrote no output is still caught.
+                const exitCodeNum = exitCode === undefined ? undefined : Number(exitCode);
+                if (exitCodeNum !== undefined && !Number.isNaN(exitCodeNum) && exitCodeNum !== 0) {
+                    status = 'failed';
+                    failureReason = `ffmpeg exited with code ${exitCodeNum}`;
+                } else {
+                    // Exit code is zero or unavailable: fall back to proving the
+                    // output exists. If no manifest URL was supplied we cannot
+                    // verify, and a job we cannot verify must NOT be reported as
+                    // completed (that is exactly the false-positive from #24).
+                    const manifestOk = await this.isMasterManifestFetchable(masterManifestUrl);
+                    if (manifestOk) {
+                        status = 'completed';
+                    } else {
+                        status = 'failed';
+                        failureReason = masterManifestUrl
+                            ? `output master manifest not fetchable at ${masterManifestUrl}`
+                            : 'output master manifest could not be verified (no manifest URL provided)';
+                    }
+                }
+            } else if (jobDetails.status === 'Failed' || jobDetails.status === 'Error' || jobDetails.status === 'FailureTarget') {
+                status = 'failed';
+            } else if (jobDetails.status === 'Suspended') {
+                status = 'suspended';
+            } else {
+                status = 'pending';
+            }
+
             if (status === 'failed') {
                 console.error(
                     `Transcoding job '${jobName}' failed (oscStatus=${jobDetails.status}) ` +
-                    `exitCode=${exitCode === undefined ? 'n/a' : exitCode}`
+                    `exitCode=${exitCode === undefined ? 'n/a' : exitCode}` +
+                    (failureReason ? ` reason=${failureReason}` : '')
                 );
                 if (stderr !== undefined) {
                     console.error(`Transcoding job '${jobName}' stderr: ${stderr}`);
@@ -591,6 +640,7 @@ class OSCClient {
                 oscStatus: jobDetails.status,
                 exitCode: exitCode,
                 stderr: stderr,
+                failureReason: failureReason,
                 details: jobDetails
             };
         } catch (error) {

--- a/src/server.js
+++ b/src/server.js
@@ -811,14 +811,21 @@ fastify.get('/api/transcode-status/:jobId', async (request, reply) => {
       return reply.code(400).send({ error: 'OSC not configured' });
     }
 
-    const jobStatus = await oscClient.getTranscodingJobStatus(jobId);
-    
+    // The expected HLS master manifest URL is needed so a terminated ("Complete")
+    // job can be confirmed to have actually written playable output before we
+    // report it as completed (issue #24). The client passes the hlsUrl it was
+    // given when the job was created.
+    const masterManifestUrl = request.query.hlsUrl;
+
+    const jobStatus = await oscClient.getTranscodingJobStatus(jobId, { masterManifestUrl });
+
     return {
       jobId: jobStatus.jobId,
       status: jobStatus.status,
       oscStatus: jobStatus.oscStatus,
       exitCode: jobStatus.exitCode,
-      stderr: jobStatus.stderr
+      stderr: jobStatus.stderr,
+      failureReason: jobStatus.failureReason
     };
 
   } catch (error) {


### PR DESCRIPTION
## Summary
- Implements #24: stop reporting a transcode as completed when the FFmpeg container terminated non-zero (e.g. exit 234) and wrote no HLS output.

## Changes
- Treat OSC `Complete`/`SuccessCriteriaMet` as "terminated, outcome unknown" rather than success.
- Map to `failed` when the FFmpeg exit code (when exposed) is non-zero.
- Map to `failed` when the expected HLS master manifest isn't fetchable in the output path (verified via existing `validateHLSUrl`).
- Surface `exitCode` and a human-readable `failureReason` on the status object, in the API response, and in the server log.
- Thread the expected manifest URL from the client poll → `/api/transcode-status` → `getTranscodingJobStatus`.
- UI now shows the failure reason instead of a bare "Transcoding failed".

## Test plan
channel-scheduler has no test runner configured (per repo convention, none was added). Verified with a throwaway node stub (removed before commit):
- PROOF Complete + non-zero exit (234) → failed (reason=ffmpeg exited with code 234)
- PROOF Complete + exit 0 + fetchable manifest → completed
- PROOF Complete + exit 0 + NON-fetchable manifest → failed (reason=output master manifest not fetchable)
- PROOF Complete + no exit code + no manifest URL → failed
- PROOF `node -e "require('./src/oscClient.js')"` loads cleanly; `node -c` on all edited files OK

Closes #24

🤖 Automated via Channel Engine Dev daily-backlog-pr skill